### PR TITLE
fix (re-render): eliminate continuous re-render

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-toast"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["YuKun Liu <mrxzx.info@gmail.com>"]
 repository = "https://github.com/mrxiaozhuox/dioxus-toast"
 license = "MIT"
@@ -20,3 +20,11 @@ chrono = { version = "0.4.19", features = ["wasmbind"] }
 dioxus = { version = "0.2.4", features = ["fermi"] }
 tokio = { version = "1.17.0", features = ["time"], optional = true }
 gloo-timers = { version = "0.2.3", features = ["futures"], optional = true }
+
+[dependencies.uuid]
+version = "1.2.1"
+features = [
+    "v4",                # Lets you generate random UUIDs
+    "fast-rng",          # Use a faster (but still sufficiently random) RNG
+    "macro-diagnostics", # Enable better diagnostics for compile-time UUIDs
+]


### PR DESCRIPTION
When there are no toasts, TostManager is updated every 100ms. Anyone who uses the library (which necessitates loading the ToastManager in an Element via use_atom_ref) will have their element reload on every update. This is no good. Don't do that. Instead, do the following

refactor the ToastManager to use a Uuid for the BTreeMap - removes the need for that buggy index logic. 
also clean up the time calculation by refactoring ToastManagerItem to calculate hide_after using an Option