### PR TITLE
fix: Only write on ToastManager signal in use_resource

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,14 +222,14 @@ pub fn ToastFrame(props: ToastFrameProps) -> Element {
 
     let _ = use_resource(move || async move {
         loop {
-            let timer_list = manager.read().list.clone();
-            for (id, item) in &timer_list {
+            let now = chrono::Local::now().timestamp();
+            manager.write().list.retain(|_, item| {
                 if let Some(hide_after) = item.hide_after {
-                    if chrono::Local::now().timestamp() >= hide_after {
-                        manager.write().list.remove(id);
-                    }
+                    now < hide_after
+                } else {
+                    true
                 }
-            }
+            });
             time_sleep(100).await;
         }
     });


### PR DESCRIPTION
This fixes a warning about reading and writing to the same signal in a reactive context.
The ToastManager signal is now only write() when removing toasts because the hide_after is in the past.

The warning fixed is:
```
10:34:00 [windows]  WARN Write on signal at C:\Users\developer\.cargo\registry\src\index.crates.io-6f17d22bba15001f\dioxus-toast-0.5.0\src/lib.rs:229:33 finished in ReactiveContext created at C:\Users\developer\.cargo\registry\src\index.crates.io-6f17d22bba15001f\dioxus-toast-0.5.0\src/lib.rs:223:13 which is also subscribed to the signal. This will likely cause an infinite loop. When the write finishes, ReactiveContext created at C:\Users\developer\.cargo\registry\src\index.crates.io-6f17d22bba15001f\dioxus-toast-0.5.0\src/lib.rs:223:13 will rerun which may cause the write to be rerun again
10:34:00 [windows] HINT:
10:34:00 [windows] This issue is caused by reading and writing to the same signal in a reactive scope. Components, effects, memos, and resources each have their own a reactive scopes. Reactive scopes rerun when any signal you read inside of them are changed. If you read and write to the same signal in the same scope, the write will cause the scope to rerun and trigger the write again. This can cause an infinite loop
```
