### PR TITLE
chore: bump to 0.6.0

### DIFF
--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus = { version = "0.5.6", features = ["web"]}
+dioxus = { version = "0.6.0", features = ["web"]}
 dioxus-toast = { path = "../", default-features = false, features = ["web"]}


### PR DESCRIPTION
Bumping dioxus in example to 0.6.0 so it runs